### PR TITLE
fix: row id may be equal to 0

### DIFF
--- a/editablegrid.js
+++ b/editablegrid.js
@@ -529,7 +529,7 @@ EditableGrid.prototype.update = function(object)
 	if (object.data) for (var i = 0; i < object.data.length; i++) 
 	{
 		var row = object.data[i];
-		if (!row.id || !row.values) continue;
+		if (row.id == undefined || !row.values) continue;
 
 		// get row to update in our model
 		var rowIndex = this.getRowIndex(row.id);


### PR DESCRIPTION
In original source code row will be skipped, if id == 0 (because 0 be cast to false), but zero is possible value.